### PR TITLE
Fixed error on legacy grub

### DIFF
--- a/gcimagebundle/gcimagebundlelib/grub.py
+++ b/gcimagebundle/gcimagebundlelib/grub.py
@@ -206,7 +206,10 @@ def InstallGrub(mount_point , partition_dev):
     logging.info(">>>> Using Grub 0.9 Installing profile")
     version = version.strip()
     logging.info(">>> Grub version detected: " + version + " (0.9+ is required)")
-    RunCommand([grub_command , "--root-directory=" + mount_point , "--modules=ext2 linux part_msdos xfs gzio normal" , str(diskpath)])
+	if grub_command == "grub-install":
+		RunCommand([grub_command , "--root-directory=" + mount_point , str(diskpath)])
+	else:
+		RunCommand([grub_command , "--root-directory=" + mount_point , "--modules=ext2 linux part_msdos xfs gzio normal" , str(diskpath)])
     uuid = RunCommand(["blkid", "-s", "UUID", "-o" , "value", partition_dev])
     uuid = str(uuid).strip()
     if os.path.exists(mount_point+"/boot/grub/grub.conf"):


### PR DESCRIPTION
Now there are all modules to be loaded due to no option "modules" is in legacy grub
